### PR TITLE
Add base_path config to app and scripts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Compile Markdown to HTML and create artifact
         run: |
-          ./scripts/package.sh
+          ENVIRONMENT=production ./scripts/package.sh
 
       - name: Upload artifact to be published
         uses: actions/upload-artifact@v4

--- a/config.rb
+++ b/config.rb
@@ -6,4 +6,7 @@ GovukTechDocs.configure(self)
 set :relative_links, true
 activate :relative_assets
 
-use OpenApiMiddleware
+# Determine the base path based on the environment variable
+base_path = ENV['BASE_PATH'] || ''
+
+use OpenApiMiddleware, base_path

--- a/openapi_middleware.rb
+++ b/openapi_middleware.rb
@@ -1,10 +1,11 @@
 class OpenApiMiddleware
-  def initialize(app)
+  def initialize(app, base_path = '')
     @app = app
+    @base_path = base_path
   end
 
   def call(env)
-    if env['PATH_INFO'] == '/openapi.json'
+    if env['PATH_INFO'] == "#{@base_path}/openapi.json"
       serve_openapi_json
     else
       @app.call(env)

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+set -e  # Exit immediately if a command exits with a non-zero status
+
+# Determine the base path based on the environment
+if [ "$ENVIRONMENT" = "production" ]; then
+  BASE_PATH="/funding-service-data-standards"
+else
+  BASE_PATH=""
+fi
+
+# Export the BASE_PATH variable so it can be used elsewhere
+export BASE_PATH
+
 # Compile the site
 bundle exec middleman build --build-dir docs --relative-links --verbose
 


### PR DESCRIPTION
- This allows the serving of the openapi json via openapi_middleware
- Should only set the longer base path during the build for GH pages