### PR TITLE
Adding basic devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/universal:2",
+    "postCreateCommand": "bundle install"
+}


### PR DESCRIPTION
I've created a very basic `devcontainer` configuration that allows this project to be opened in codespaces with dependencies already installed.

It means you can use 'launch in codespace' and then just execute `bundle exec middleman server` to see it run.