### PR TITLE
Reorder fields and fix a schema reference

### DIFF
--- a/source/organisation.html.md.erb
+++ b/source/organisation.html.md.erb
@@ -28,8 +28,8 @@ This data standard describes the information MHCLG collects about organisations,
 The organisation data standard consists of the following entities:
 
 - **Organisation** - the main data entity detailing Organisation information
-- **Person** - the main contact for the organisation
 - **Address** - the primary contact address
+- **Person** - the main contact for the organisation
 
 ## Organisation standards  
 
@@ -64,6 +64,14 @@ An alternative name of the organisation.
 **Conditions:** Optional  
 **Validation:** Fewer than 160 characters.  
 
+### Charity Commission number
+The Charity Commission number for the charity.
+
+**Data type:** String
+**Format:** Alphanumeric
+**Conditions:** This must be supplied if the organisation is a charity.
+**Validation:** It must be a number between 6 and 8 characters. A hyphen can be used for the first character.
+
 ### Companies House reference number  
 The Companies House registration number for the organisation.   
 
@@ -71,14 +79,6 @@ The Companies House registration number for the organisation.
 **Format:**   Alphanumeric  
 **Conditions:** This must be supplied if the organisation is a limited company.   
 **Validation:** 8 numbers, or 2 letters followed by 6 numbers.   
-
-### Charity Commission number  
-The Charity Commission number for the charity.  
-
-**Data type:** String  
-**Format:** Alphanumeric  
-**Conditions:** This must be supplied if the organisation is a charity.  
-**Validation:** It must be a number between 6 and 8 characters. A hyphen can be used for the first character.  
 
 ### Local Authority code  
 
@@ -211,7 +211,7 @@ This standard is automatically generated and the data provider does not need to 
             "default": "Local authority"
         },
         "address": {
-            "$ref": "schemas/user.schema.json",
+            "$ref": "schemas/address.schema.json",
             "description": "A reference to the Address of the Organisation."
         },
         "primary_contact": {


### PR DESCRIPTION
Reorder charity+LTD company to match the order of the bullets under 'Organisation type'

Reorder person/address under the 'Data entities' header to match the order they're listed under the 'Organisation standards' and 'JSON schema' headers

Fix the JSON schema reference for the address